### PR TITLE
Add react player package and test implementation

### DIFF
--- a/docs/slides_example.mdx
+++ b/docs/slides_example.mdx
@@ -1,0 +1,23 @@
+---
+title: Example with embedded slides
+---
+
+<iframe
+  src="https://docs.google.com/presentation/d/1_4mdCXh5KjRn-A9XY_eW_gav36qwPw8m7Ew3WFLosw0/edit?usp=sharing"
+  width="100%"
+  height="500px"
+  frameborder="0"
+  allowfullscreen
+></iframe>
+
+<iframe
+  src="https://docs.google.com/presentation/d/1ZFDauAO1HYVxn22jpUcBuekZuWUMFuup/edit?usp=sharing&ouid=106914048811184527917&rtpof=true&sd=true"
+  width="100%"
+  height="500px"
+  frameborder="0"
+  allowfullscreen
+></iframe>
+
+[Symbiota Docs v1.new](https://symbiota.org/docs) is a central repository for documentation regarding Symbiota-based data portals. This site is maintained by the Symbiota Support Hub, but all Symbiota users are encouraged to contribute. [Contact Us](https://biokic.github.io/symbiota-docs/contact/) to contribute or provide feedback on this site.
+
+[Symbiota](https://symbiota.org/) is an open-source software for managing and mobilizing biodiversity data that serves over 2,000 natural history collections and publishes over 95 million occurrence (specimen or observation) records. Visit [Symbiota.org](https://symbiota.org/) to learn more. The core Symbiota code is developed at the Arizona State University Biodiversity Knowledge Integration Center. The central code for this version of Symbiota can be found in [GitHub](https://github.com/BioKIC/Symbiota).

--- a/docs/video_example.mdx
+++ b/docs/video_example.mdx
@@ -1,0 +1,15 @@
+---
+title: Example with embedded video
+---
+
+import ReactPlayer from "react-player";
+
+<ReactPlayer
+  playing
+  controls
+  url="https://youtu.be/SCJxEhG-CZQ?si=9FG2NGqpHCxe6V5I"
+/>
+
+[Symbiota Docs v1.new](https://symbiota.org/docs) is a central repository for documentation regarding Symbiota-based data portals. This site is maintained by the Symbiota Support Hub, but all Symbiota users are encouraged to contribute. [Contact Us](https://biokic.github.io/symbiota-docs/contact/) to contribute or provide feedback on this site.
+
+[Symbiota](https://symbiota.org/) is an open-source software for managing and mobilizing biodiversity data that serves over 2,000 natural history collections and publishes over 95 million occurrence (specimen or observation) records. Visit [Symbiota.org](https://symbiota.org/) to learn more. The core Symbiota code is developed at the Arizona State University Biodiversity Knowledge Integration Center. The central code for this version of Symbiota can be found in [GitHub](https://github.com/BioKIC/Symbiota).

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "clsx": "^2.0.0",
         "prism-react-renderer": "^2.3.0",
         "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "react-dom": "^19.0.0",
+        "react-player": "^2.16.0"
       },
       "devDependencies": {
         "@docusaurus/module-type-aliases": "3.7.0",
@@ -9849,6 +9850,12 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "license": "MIT"
     },
+    "node_modules/load-script": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/load-script/-/load-script-1.0.0.tgz",
+      "integrity": "sha512-kPEjMFtZvwL9TaZo0uZ2ml+Ye9HUMmPwbYRJ324qF9tqMejwykJ5ggTyvzmrbBeapCAbk98BSbTeovHEEP1uCA==",
+      "license": "MIT"
+    },
     "node_modules/loader-runner": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
@@ -10422,6 +10429,12 @@
       "engines": {
         "node": ">= 4.0.0"
       }
+    },
+    "node_modules/memoize-one": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
+      "license": "MIT"
     },
     "node_modules/merge-descriptors": {
       "version": "1.0.3",
@@ -15005,6 +15018,22 @@
       "peerDependencies": {
         "react-loadable": "*",
         "webpack": ">=4.41.1 || 5.x"
+      }
+    },
+    "node_modules/react-player": {
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/react-player/-/react-player-2.16.0.tgz",
+      "integrity": "sha512-mAIPHfioD7yxO0GNYVFD1303QFtI3lyyQZLY229UEAp/a10cSW+hPcakg0Keq8uWJxT2OiT/4Gt+Lc9bD6bJmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "deepmerge": "^4.0.0",
+        "load-script": "^1.0.0",
+        "memoize-one": "^5.1.1",
+        "prop-types": "^15.7.2",
+        "react-fast-compare": "^3.0.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
       }
     },
     "node_modules/react-router": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "clsx": "^2.0.0",
     "prism-react-renderer": "^2.3.0",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "react-player": "^2.16.0"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "3.7.0",


### PR DESCRIPTION
# Description

This PR adds a new package to the repo. that allows videos to be embedded. It also adds an example .mdx file that shows how one could implement video embedding.

The docs/video_example.mdx file could be deleted in a future PR, but the updates to package.json (and package-lock.json) are essential for this to work in future versions.

Update: I also added a docs/slides_example.mdx to show how an <iframe> can be used to embed google slides or a .ppt saved on google drive.

I still need to find a good way to render a pdf. Ongoing work; likely, a separate PR.