### PR TITLE
Moving misplaced instructions for traits

### DIFF
--- a/versioned_docs/version-3.3/Editor_Guide/Traits/Traits.md
+++ b/versioned_docs/version-3.3/Editor_Guide/Traits/Traits.md
@@ -1,6 +1,6 @@
 ---
 title: "Traits"
-date: 2021-12-09
+date: 2025-12-22
 draft: false
 weight: 130
 authors: ["Katie Pearson"]
@@ -14,3 +14,9 @@ Traits are stored in a separate table than the main occurrence data and can be v
 Traits can often be downloaded along with occurrence data as an [extended measurementOrFact file](https://tools.gbif.org/dwca-validator/extension.do?id=http://rs.iobis.org/obis/terms/ExtendedMeasurementOrFact).
 
 Several tools have been developed to enable users to annotate specimen records for their traits, including the [Trait Coding from Images](/Editor_Guide/Traits/trait_scoring_images) tool and the [Trait Coding from Text](/Editor_Guide/Traits/trait_scoring_text) tool. The traits available to score vary between portals, and new traits can be developed as needed (contact your portal administrator for more information).
+
+### Scoring traits for a single specimen
+
+Navigate to the Occurence Editor for the occurrence you wish to score (see [this page](/Editor_Guide/Editing_Searching_Records) for help finding specimens) and click on the Traits tab. Any traits available for scoring will be displayed in boxes in this tab. To view additional scoring optiosn for a given trait, click the black triangle at the top right of the box (highlighted below). From here, you can score the traits from any available images. You can also remove trait information by clicking the Delete Coding button.
+
+![Traits Tab](/img/traitstab.png)

--- a/versioned_docs/version-3.3/Editor_Guide/Traits/trait_scoring_images.md
+++ b/versioned_docs/version-3.3/Editor_Guide/Traits/trait_scoring_images.md
@@ -1,6 +1,6 @@
 ---
 title: "Trait Scoring from Images"
-date: 2021-12-09
+date: 2025-12-22
 draft: false
 authors: ["Katie Pearson"]
 keywords: ["trait scoring", "attribute scoring", "phenology", "traits"]
@@ -17,12 +17,6 @@ This page describes how to score traits for an occurrence from an image of that 
 Trait scoring tools are not activated in all portals. Contact your portal manager for more information.
 
 :::
-
-### Scoring traits for a single specimen
-
-Navigate to the Occurence Editor for the occurrence you wish to score (see [this page](/Editor_Guide/Editing_Searching_Records) for help finding specimens) and click on the Traits tab. Any traits available for scoring will be displayed in boxes in this tab. To view additional scoring optiosn for a given trait, click the black triangle at the top right of the box (highlighted below). From here, you can score the traits from any available images. You can also remove trait information by clicking the Delete Coding button.
-
-![Traits Tab](/img/traitstab.png)
 
 ### Scoring traits using the Trait Scoring from Images tools
 


### PR DESCRIPTION
The instructions for use the basic trait editing interface were hidden away on the page for the Trait Coding from Images tool for some reason. This moves those instructions to the main Traits page (Traits.md) so they are easier to find.